### PR TITLE
Fix '<' and '>' font size handling in execorder.

### DIFF
--- a/execorder/index.html
+++ b/execorder/index.html
@@ -28,9 +28,9 @@
 </body>
 <script type='text/javascript'>
 function keypress(e) {
-	var key = e.keyCode;
-	if (key != 60 && key != 62) return;
-	var adj = (key == 60) ? -1 : +1;
+	var key = e.key;
+	if (key != "<" && key != ">") return;
+	var adj = (key == "<") ? -1 : +1;
 	var eo = document.getElementById('eo');
 	var size = parseInt(eo.style['font-size']);
 	eo.style['font-size'] = (size + adj) + 'px';


### PR DESCRIPTION
Thanks, Firefox debugger! :D