### PR TITLE
pmp: redesign landing page with dark sidebar and ruled content

### DIFF
--- a/pmp/preview-a.html
+++ b/pmp/preview-a.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<!-- Design A: Deep Sidebar — dark warm sidebar, unchanged parchment content -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview A — Deep Sidebar</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet" />
+  <style>
+/* ── Variables ───────────────────────────────────────────── */
+:root {
+  --bg:              #f6f1e7;
+  --sidebar-bg:      #1a0f06;
+  --sidebar-border:  #3a2008;
+  --text:            #2a1e0d;
+  --text-muted:      #7a6548;
+  --heading:         #3a2710;
+  --accent:          #8b5e26;
+  --accent-light:    #c4922e;
+  --link:            #6b4718;
+  --link-hover:      #a06828;
+  --border:          #d4c4a0;
+  --category:        #4a5c35;
+  --active-bg:       #2d1808;
+  --active-bar:      #c4922e;
+  --quote-bg:        #ede5d0;
+  --sidebar-width:   260px;
+  --font-serif:      'Lora', Georgia, serif;
+
+  /* sidebar-specific */
+  --s-text:          #b8a07a;
+  --s-text-heading:  #ddc8a0;
+  --s-category:      #6fa04a;
+  --s-hover-bg:      #2d1808;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 17px; }
+body {
+  font-family: var(--font-serif);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.75;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+#layout { display: flex; min-height: 100vh; }
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0;
+  height: 100vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+
+#sidebar-header {
+  padding: 1.75rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+
+#site-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  text-decoration: none;
+  color: var(--s-text-heading);
+  transition: color 0.15s;
+}
+#site-title:hover { color: var(--accent-light); }
+
+.title-main {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+}
+
+#sidebar-nav { padding: 0.75rem 0 2rem; flex: 1; }
+
+.nav-top {
+  list-style: none;
+  padding: 0 0 0.5rem;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 0.5rem;
+}
+.nav-top li a {
+  display: block;
+  padding: 0.35rem 1.25rem;
+  font-size: 0.875rem;
+  color: var(--s-text);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.nav-top li a:hover { background: var(--s-hover-bg); color: var(--s-text-heading); }
+.nav-top li a.active {
+  border-left-color: var(--active-bar);
+  color: var(--s-text-heading);
+  background: var(--s-hover-bg);
+  font-weight: 500;
+}
+
+.nav-category { margin-top: 0.25rem; }
+.nav-category-title {
+  display: block;
+  padding: 0.75rem 1.25rem 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--s-category);
+}
+.nav-category ul { list-style: none; }
+.nav-category ul li a {
+  display: block;
+  padding: 0.3rem 1.25rem 0.3rem 1.5rem;
+  font-size: 0.825rem;
+  color: var(--s-text);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  line-height: 1.4;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.nav-category ul li a:hover { background: var(--s-hover-bg); color: var(--s-text-heading); }
+.nav-category ul li a.active {
+  border-left-color: var(--active-bar);
+  color: var(--s-text-heading);
+  background: var(--s-hover-bg);
+  font-weight: 500;
+}
+
+/* ── Main content ────────────────────────────────────────── */
+#content {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 2.5rem 6rem;
+}
+#page { width: 100%; max-width: 680px; }
+
+/* ── Landing page ────────────────────────────────────────── */
+.landing-header { margin-bottom: 1.5rem; }
+.landing-title {
+  font-size: 1.75rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--heading);
+  margin-bottom: 0.3rem;
+}
+.landing-byline {
+  font-size: 0.875rem;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.landing-description {
+  font-size: 0.975rem;
+  color: var(--text);
+  line-height: 1.75;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.toc-frontmatter {
+  display: flex;
+  gap: 2rem;
+  padding-bottom: 1.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.toc-frontmatter-link {
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--link);
+}
+.toc-frontmatter-link:hover { color: var(--link-hover); }
+
+.toc-section { margin-top: 2rem; }
+.toc-section-title {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--category);
+  margin-bottom: 0.75rem;
+}
+.toc-patterns { list-style: none; padding: 0; }
+.toc-pattern {
+  display: flex;
+  flex-direction: column;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.toc-pattern:last-child { border-bottom: none; }
+.toc-pattern-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--link);
+  text-decoration: none;
+  line-height: 1.4;
+  margin-bottom: 0.15rem;
+}
+.toc-pattern-title:hover { color: var(--link-hover); }
+.toc-pattern-summary {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+  </style>
+</head>
+<body>
+<div id="layout">
+
+  <nav id="sidebar">
+    <div id="sidebar-header">
+      <a href="#" id="site-title">
+        <span class="title-main">A Pattern Language for Product Management</span>
+      </a>
+    </div>
+    <div id="sidebar-nav">
+      <ul class="nav-top">
+        <li><a href="#" class="nav-link">Introduction</a></li>
+        <li><a href="#" class="nav-link active">Contents</a></li>
+        <li><a href="#" class="nav-link">About</a></li>
+      </ul>
+      <div id="nav-categories">
+        <div class="nav-category">
+          <span class="nav-category-title">Meaning &amp; Communication</span>
+          <ul>
+            <li><a href="#">Alignment Mirage</a></li>
+            <li><a href="#">Cultural Dialects</a></li>
+            <li><a href="#">Explanatory Power vs Precision</a></li>
+            <li><a href="#">Surface Consensus</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Systems &amp; Incentives</span>
+          <ul>
+            <li><a href="#">Conservation of Organizational Cost</a></li>
+            <li><a href="#">Dual Competence</a></li>
+            <li><a href="#">Perverse Correlation</a></li>
+            <li><a href="#">Reward Loop Asymmetry</a></li>
+            <li><a href="#">Symbolic Friction</a></li>
+            <li><a href="#">Fluency Capture</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Vision &amp; Strategy</span>
+          <ul>
+            <li><a href="#">Creating Gravity</a></li>
+            <li><a href="#">Elastic Leadership</a></li>
+            <li><a href="#">Vision Anchoring</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Product &amp; User</span>
+          <ul>
+            <li><a href="#">Algorithm–Product Gap</a></li>
+            <li><a href="#">Ontology Leakage</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main id="content">
+    <article id="page">
+      <div class="landing-header">
+        <h1 class="landing-title">A Pattern Language for Product Management in Complex Organizations</h1>
+        <p class="landing-byline">Isaac Hepworth</p>
+      </div>
+      <p class="landing-description">A reference vocabulary for the dynamics that experienced PMs recognize but have never quite pulled into focus.</p>
+      <nav class="toc">
+        <div class="toc-frontmatter">
+          <a href="#" class="toc-frontmatter-link">Introduction</a>
+          <a href="#" class="toc-frontmatter-link">About</a>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Meaning &amp; Communication</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Alignment Mirage</a>
+              <span class="toc-pattern-summary">The illusion of shared understanding when language scales faster than meaning.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Cultural Dialects</a>
+              <span class="toc-pattern-summary">The emergence of different sub-languages within an organization.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Explanatory Power vs Precision</a>
+              <span class="toc-pattern-summary">The trade-off between clarity and detail in communication.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Surface Consensus</a>
+              <span class="toc-pattern-summary">The illusion of agreement in a group, masking underlying differences.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Systems &amp; Incentives</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Conservation of Organizational Cost</a>
+              <span class="toc-pattern-summary">The idea that costs in an organization are not eliminated, but shifted.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Dual Competence</a>
+              <span class="toc-pattern-summary">The need for both product craftsmanship and organizational navigation skills.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Perverse Correlation</a>
+              <span class="toc-pattern-summary">When a metric becomes a target and its meaning inverts.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Reward Loop Asymmetry</a>
+              <span class="toc-pattern-summary">The tendency for short-term, visible rewards to dominate behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Symbolic Friction</a>
+              <span class="toc-pattern-summary">Introducing a small, visible cost to correct a behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Fluency Capture</a>
+              <span class="toc-pattern-summary">When an organization's feedback mechanisms are captured by those whose incentive is to defeat them.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Vision &amp; Strategy</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Creating Gravity</a>
+              <span class="toc-pattern-summary">Using a strong vision to create alignment without direct control.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Elastic Leadership</a>
+              <span class="toc-pattern-summary">The balance between a long-term vision and the team's current reality.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Vision Anchoring</a>
+              <span class="toc-pattern-summary">Framing a product within a larger, aspirational narrative.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Product &amp; User</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Algorithm–Product Gap</a>
+              <span class="toc-pattern-summary">The disconnect between a model's technical success and its value to users.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Ontology Leakage</a>
+              <span class="toc-pattern-summary">When a company's internal model of the world is exposed to users.</span>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </article>
+  </main>
+
+</div>
+</body>
+</html>

--- a/pmp/preview-b.html
+++ b/pmp/preview-b.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<!-- Design B: Ruled — same palette, bolder typographic structure on the landing page -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview B — Ruled</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet" />
+  <style>
+/* ── Variables ───────────────────────────────────────────── */
+:root {
+  --bg:              #f6f1e7;
+  --sidebar-bg:      #ece4ce;
+  --sidebar-border:  #d8ccb0;
+  --text:            #2a1e0d;
+  --text-muted:      #7a6548;
+  --heading:         #3a2710;
+  --accent:          #8b5e26;
+  --accent-light:    #c4922e;
+  --link:            #6b4718;
+  --link-hover:      #a06828;
+  --border:          #d4c4a0;
+  --category:        #4a5c35;
+  --active-bg:       #ddd0b0;
+  --active-bar:      #8b5e26;
+  --sidebar-width:   260px;
+  --font-serif:      'Lora', Georgia, serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 17px; }
+body {
+  font-family: var(--font-serif);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.75;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+#layout { display: flex; min-height: 100vh; }
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0;
+  height: 100vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+#sidebar-header {
+  padding: 1.75rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+#site-title {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--heading);
+}
+#site-title:hover { color: var(--accent); }
+.title-main {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+}
+#sidebar-nav { padding: 0.75rem 0 2rem; flex: 1; }
+.nav-top {
+  list-style: none;
+  padding: 0 0 0.5rem;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 0.5rem;
+}
+.nav-top li a {
+  display: block;
+  padding: 0.35rem 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, color 0.12s;
+}
+.nav-top li a:hover { background: var(--active-bg); color: var(--heading); }
+.nav-top li a.active {
+  border-left-color: var(--active-bar);
+  color: var(--heading);
+  background: var(--active-bg);
+  font-weight: 500;
+}
+.nav-category { margin-top: 0.25rem; }
+.nav-category-title {
+  display: block;
+  padding: 0.75rem 1.25rem 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--category);
+}
+.nav-category ul { list-style: none; }
+.nav-category ul li a {
+  display: block;
+  padding: 0.3rem 1.25rem 0.3rem 1.5rem;
+  font-size: 0.825rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  line-height: 1.4;
+  transition: background 0.12s, color 0.12s;
+}
+.nav-category ul li a:hover { background: var(--active-bg); color: var(--heading); }
+.nav-category ul li a.active {
+  border-left-color: var(--active-bar);
+  color: var(--heading);
+  background: var(--active-bg);
+  font-weight: 500;
+}
+
+/* ── Main content ────────────────────────────────────────── */
+#content {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 4rem 2.5rem 6rem;
+}
+#page { width: 100%; max-width: 680px; }
+
+/* ── Landing: RULED design ───────────────────────────────── */
+.landing-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px solid var(--accent);
+}
+.landing-title {
+  font-size: 2.4rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--heading);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+}
+.landing-byline {
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--text-muted);
+}
+
+.landing-description {
+  font-size: 0.975rem;
+  color: var(--text);
+  line-height: 1.75;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.toc-frontmatter {
+  display: flex;
+  gap: 2rem;
+  padding-bottom: 1.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.toc-frontmatter-link {
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--link);
+}
+.toc-frontmatter-link:hover { color: var(--link-hover); }
+
+/* Category sections: each has a left accent rule */
+.toc-section {
+  margin-top: 2.25rem;
+  padding-left: 1.1rem;
+  border-left: 2px solid var(--border);
+}
+.toc-section-title {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 0.85rem;
+}
+.toc-patterns { list-style: none; padding: 0; }
+.toc-pattern {
+  display: flex;
+  flex-direction: column;
+  padding: 0.7rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.toc-pattern:last-child { border-bottom: none; }
+.toc-pattern-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--link);
+  text-decoration: none;
+  line-height: 1.4;
+  margin-bottom: 0.15rem;
+}
+.toc-pattern-title:hover { color: var(--link-hover); }
+.toc-pattern-summary {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+  </style>
+</head>
+<body>
+<div id="layout">
+
+  <nav id="sidebar">
+    <div id="sidebar-header">
+      <a href="#" id="site-title">
+        <span class="title-main">A Pattern Language for Product Management</span>
+      </a>
+    </div>
+    <div id="sidebar-nav">
+      <ul class="nav-top">
+        <li><a href="#">Introduction</a></li>
+        <li><a href="#" class="active">Contents</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+      <div>
+        <div class="nav-category">
+          <span class="nav-category-title">Meaning &amp; Communication</span>
+          <ul>
+            <li><a href="#">Alignment Mirage</a></li>
+            <li><a href="#">Cultural Dialects</a></li>
+            <li><a href="#">Explanatory Power vs Precision</a></li>
+            <li><a href="#">Surface Consensus</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Systems &amp; Incentives</span>
+          <ul>
+            <li><a href="#">Conservation of Organizational Cost</a></li>
+            <li><a href="#">Dual Competence</a></li>
+            <li><a href="#">Perverse Correlation</a></li>
+            <li><a href="#">Reward Loop Asymmetry</a></li>
+            <li><a href="#">Symbolic Friction</a></li>
+            <li><a href="#">Fluency Capture</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Vision &amp; Strategy</span>
+          <ul>
+            <li><a href="#">Creating Gravity</a></li>
+            <li><a href="#">Elastic Leadership</a></li>
+            <li><a href="#">Vision Anchoring</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Product &amp; User</span>
+          <ul>
+            <li><a href="#">Algorithm–Product Gap</a></li>
+            <li><a href="#">Ontology Leakage</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main id="content">
+    <article id="page">
+      <div class="landing-header">
+        <h1 class="landing-title">A Pattern Language for Product Management in Complex Organizations</h1>
+        <p class="landing-byline">Isaac Hepworth</p>
+      </div>
+      <p class="landing-description">A reference vocabulary for the dynamics that experienced PMs recognize but have never quite pulled into focus.</p>
+      <nav class="toc">
+        <div class="toc-frontmatter">
+          <a href="#" class="toc-frontmatter-link">Introduction</a>
+          <a href="#" class="toc-frontmatter-link">About</a>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Meaning &amp; Communication</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Alignment Mirage</a>
+              <span class="toc-pattern-summary">The illusion of shared understanding when language scales faster than meaning.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Cultural Dialects</a>
+              <span class="toc-pattern-summary">The emergence of different sub-languages within an organization.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Explanatory Power vs Precision</a>
+              <span class="toc-pattern-summary">The trade-off between clarity and detail in communication.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Surface Consensus</a>
+              <span class="toc-pattern-summary">The illusion of agreement in a group, masking underlying differences.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Systems &amp; Incentives</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Conservation of Organizational Cost</a>
+              <span class="toc-pattern-summary">The idea that costs in an organization are not eliminated, but shifted.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Dual Competence</a>
+              <span class="toc-pattern-summary">The need for both product craftsmanship and organizational navigation skills.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Perverse Correlation</a>
+              <span class="toc-pattern-summary">When a metric becomes a target and its meaning inverts.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Reward Loop Asymmetry</a>
+              <span class="toc-pattern-summary">The tendency for short-term, visible rewards to dominate behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Symbolic Friction</a>
+              <span class="toc-pattern-summary">Introducing a small, visible cost to correct a behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Fluency Capture</a>
+              <span class="toc-pattern-summary">When an organization's feedback mechanisms are captured by those whose incentive is to defeat them.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Vision &amp; Strategy</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Creating Gravity</a>
+              <span class="toc-pattern-summary">Using a strong vision to create alignment without direct control.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Elastic Leadership</a>
+              <span class="toc-pattern-summary">The balance between a long-term vision and the team's current reality.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Vision Anchoring</a>
+              <span class="toc-pattern-summary">Framing a product within a larger, aspirational narrative.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Product &amp; User</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Algorithm–Product Gap</a>
+              <span class="toc-pattern-summary">The disconnect between a model's technical success and its value to users.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Ontology Leakage</a>
+              <span class="toc-pattern-summary">When a company's internal model of the world is exposed to users.</span>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </article>
+  </main>
+
+</div>
+</body>
+</html>

--- a/pmp/preview-c.html
+++ b/pmp/preview-c.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<!-- Design C: Masthead — dark header band on landing page, warm parchment body below -->
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview C — Masthead</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap" rel="stylesheet" />
+  <style>
+/* ── Variables ───────────────────────────────────────────── */
+:root {
+  --bg:              #f6f1e7;
+  --sidebar-bg:      #ece4ce;
+  --sidebar-border:  #d8ccb0;
+  --text:            #2a1e0d;
+  --text-muted:      #7a6548;
+  --heading:         #3a2710;
+  --accent:          #8b5e26;
+  --accent-light:    #c4922e;
+  --link:            #6b4718;
+  --link-hover:      #a06828;
+  --border:          #d4c4a0;
+  --category:        #4a5c35;
+  --active-bg:       #ddd0b0;
+  --active-bar:      #8b5e26;
+  --masthead-bg:     #1a0f06;
+  --masthead-title:  #f0e2c8;
+  --masthead-desc:   #b8a07a;
+  --masthead-byline: #7a6040;
+  --sidebar-width:   260px;
+  --font-serif:      'Lora', Georgia, serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 17px; }
+body {
+  font-family: var(--font-serif);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.75;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── Layout ──────────────────────────────────────────────── */
+#layout { display: flex; min-height: 100vh; }
+
+/* ── Sidebar ─────────────────────────────────────────────── */
+#sidebar {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--sidebar-border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0;
+  height: 100vh;
+  overflow-y: auto;
+  z-index: 100;
+}
+#sidebar-header {
+  padding: 1.75rem 1.25rem 1.25rem;
+  border-bottom: 1px solid var(--sidebar-border);
+}
+#site-title {
+  display: flex;
+  flex-direction: column;
+  text-decoration: none;
+  color: var(--heading);
+}
+#site-title:hover { color: var(--accent); }
+.title-main {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: 0.01em;
+}
+#sidebar-nav { padding: 0.75rem 0 2rem; flex: 1; }
+.nav-top {
+  list-style: none;
+  padding: 0 0 0.5rem;
+  border-bottom: 1px solid var(--sidebar-border);
+  margin-bottom: 0.5rem;
+}
+.nav-top li a {
+  display: block;
+  padding: 0.35rem 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  transition: background 0.12s, color 0.12s;
+}
+.nav-top li a:hover { background: var(--active-bg); color: var(--heading); }
+.nav-top li a.active {
+  border-left-color: var(--active-bar);
+  color: var(--heading);
+  background: var(--active-bg);
+  font-weight: 500;
+}
+.nav-category { margin-top: 0.25rem; }
+.nav-category-title {
+  display: block;
+  padding: 0.75rem 1.25rem 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--category);
+}
+.nav-category ul { list-style: none; }
+.nav-category ul li a {
+  display: block;
+  padding: 0.3rem 1.25rem 0.3rem 1.5rem;
+  font-size: 0.825rem;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-left: 2px solid transparent;
+  line-height: 1.4;
+  transition: background 0.12s, color 0.12s;
+}
+.nav-category ul li a:hover { background: var(--active-bg); color: var(--heading); }
+
+/* ── Main content ────────────────────────────────────────── */
+#content {
+  margin-left: var(--sidebar-width);
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: 0 0 6rem;        /* no top padding — masthead fills it */
+}
+#page { width: 100%; max-width: 680px; }
+
+/* ── Landing: MASTHEAD design ────────────────────────────── */
+
+/* Dark header band — extends full-width within content column */
+.landing-masthead {
+  background: var(--masthead-bg);
+  padding: 4rem 2.5rem 3rem;
+  margin-bottom: 0;
+}
+.landing-title {
+  font-size: 2.2rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--masthead-title);
+  margin-bottom: 0.5rem;
+  letter-spacing: -0.01em;
+}
+.landing-byline {
+  font-size: 0.875rem;
+  font-style: italic;
+  color: var(--masthead-byline);
+  margin-bottom: 1.25rem;
+}
+.landing-description {
+  font-size: 0.975rem;
+  color: var(--masthead-desc);
+  line-height: 1.75;
+}
+
+/* TOC — warm parchment background, padded to match */
+.toc {
+  padding: 2.5rem 2.5rem 0;
+}
+
+.toc-frontmatter {
+  display: flex;
+  gap: 2rem;
+  padding-bottom: 1.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.toc-frontmatter-link {
+  font-size: 1rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--link);
+}
+.toc-frontmatter-link:hover { color: var(--link-hover); }
+
+.toc-section { margin-top: 2rem; }
+.toc-section-title {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--category);
+  margin-bottom: 0.75rem;
+}
+.toc-patterns { list-style: none; padding: 0; }
+.toc-pattern {
+  display: flex;
+  flex-direction: column;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.toc-pattern:last-child { border-bottom: none; }
+.toc-pattern-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--link);
+  text-decoration: none;
+  line-height: 1.4;
+  margin-bottom: 0.15rem;
+}
+.toc-pattern-title:hover { color: var(--link-hover); }
+.toc-pattern-summary {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+  </style>
+</head>
+<body>
+<div id="layout">
+
+  <nav id="sidebar">
+    <div id="sidebar-header">
+      <a href="#" id="site-title">
+        <span class="title-main">A Pattern Language for Product Management</span>
+      </a>
+    </div>
+    <div id="sidebar-nav">
+      <ul class="nav-top">
+        <li><a href="#">Introduction</a></li>
+        <li><a href="#" class="active">Contents</a></li>
+        <li><a href="#">About</a></li>
+      </ul>
+      <div>
+        <div class="nav-category">
+          <span class="nav-category-title">Meaning &amp; Communication</span>
+          <ul>
+            <li><a href="#">Alignment Mirage</a></li>
+            <li><a href="#">Cultural Dialects</a></li>
+            <li><a href="#">Explanatory Power vs Precision</a></li>
+            <li><a href="#">Surface Consensus</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Systems &amp; Incentives</span>
+          <ul>
+            <li><a href="#">Conservation of Organizational Cost</a></li>
+            <li><a href="#">Dual Competence</a></li>
+            <li><a href="#">Perverse Correlation</a></li>
+            <li><a href="#">Reward Loop Asymmetry</a></li>
+            <li><a href="#">Symbolic Friction</a></li>
+            <li><a href="#">Fluency Capture</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Vision &amp; Strategy</span>
+          <ul>
+            <li><a href="#">Creating Gravity</a></li>
+            <li><a href="#">Elastic Leadership</a></li>
+            <li><a href="#">Vision Anchoring</a></li>
+          </ul>
+        </div>
+        <div class="nav-category">
+          <span class="nav-category-title">Product &amp; User</span>
+          <ul>
+            <li><a href="#">Algorithm–Product Gap</a></li>
+            <li><a href="#">Ontology Leakage</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main id="content">
+    <article id="page">
+
+      <!-- Dark masthead band -->
+      <div class="landing-masthead">
+        <h1 class="landing-title">A Pattern Language for Product Management in Complex Organizations</h1>
+        <p class="landing-byline">Isaac Hepworth</p>
+        <p class="landing-description">A reference vocabulary for the dynamics that experienced PMs recognize but have never quite pulled into focus.</p>
+      </div>
+
+      <!-- Warm parchment TOC -->
+      <nav class="toc">
+        <div class="toc-frontmatter">
+          <a href="#" class="toc-frontmatter-link">Introduction</a>
+          <a href="#" class="toc-frontmatter-link">About</a>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Meaning &amp; Communication</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Alignment Mirage</a>
+              <span class="toc-pattern-summary">The illusion of shared understanding when language scales faster than meaning.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Cultural Dialects</a>
+              <span class="toc-pattern-summary">The emergence of different sub-languages within an organization.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Explanatory Power vs Precision</a>
+              <span class="toc-pattern-summary">The trade-off between clarity and detail in communication.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Surface Consensus</a>
+              <span class="toc-pattern-summary">The illusion of agreement in a group, masking underlying differences.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Systems &amp; Incentives</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Conservation of Organizational Cost</a>
+              <span class="toc-pattern-summary">The idea that costs in an organization are not eliminated, but shifted.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Dual Competence</a>
+              <span class="toc-pattern-summary">The need for both product craftsmanship and organizational navigation skills.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Perverse Correlation</a>
+              <span class="toc-pattern-summary">When a metric becomes a target and its meaning inverts.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Reward Loop Asymmetry</a>
+              <span class="toc-pattern-summary">The tendency for short-term, visible rewards to dominate behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Symbolic Friction</a>
+              <span class="toc-pattern-summary">Introducing a small, visible cost to correct a behavior.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Fluency Capture</a>
+              <span class="toc-pattern-summary">When an organization's feedback mechanisms are captured by those whose incentive is to defeat them.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Vision &amp; Strategy</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Creating Gravity</a>
+              <span class="toc-pattern-summary">Using a strong vision to create alignment without direct control.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Elastic Leadership</a>
+              <span class="toc-pattern-summary">The balance between a long-term vision and the team's current reality.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Vision Anchoring</a>
+              <span class="toc-pattern-summary">Framing a product within a larger, aspirational narrative.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="toc-section">
+          <h2 class="toc-section-title">Product &amp; User</h2>
+          <ul class="toc-patterns">
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Algorithm–Product Gap</a>
+              <span class="toc-pattern-summary">The disconnect between a model's technical success and its value to users.</span>
+            </li>
+            <li class="toc-pattern">
+              <a href="#" class="toc-pattern-title">Ontology Leakage</a>
+              <span class="toc-pattern-summary">When a company's internal model of the world is exposed to users.</span>
+            </li>
+          </ul>
+        </div>
+      </nav>
+    </article>
+  </main>
+
+</div>
+</body>
+</html>

--- a/pmp/style.css
+++ b/pmp/style.css
@@ -1,8 +1,8 @@
 /* ── Variables ──────────────────────────────────────────────── */
 :root {
   --bg:            #f6f1e7;
-  --sidebar-bg:    #ece4ce;
-  --sidebar-border:#d8ccb0;
+  --sidebar-bg:    #1a0f06;
+  --sidebar-border:#3a2008;
   --text:          #2a1e0d;
   --text-muted:    #7a6548;
   --heading:       #3a2710;
@@ -12,8 +12,8 @@
   --link-hover:    #a06828;
   --border:        #d4c4a0;
   --category:      #4a5c35;
-  --active-bg:     #ddd0b0;
-  --active-bar:    #8b5e26;
+  --active-bg:     #2d1808;
+  --active-bar:    #c4922e;
   --quote-bg:      #ede5d0;
   --quote-bar:     #b89050;
   --sidebar-width: 260px;
@@ -80,9 +80,9 @@ a:hover {
   flex-direction: column;
   gap: 0.15rem;
   text-decoration: none;
-  color: var(--heading);
+  color: #ddc8a0;
 }
-#site-title:hover { color: var(--accent); }
+#site-title:hover { color: var(--accent-light); }
 
 .title-main {
   font-size: 0.95rem;
@@ -94,7 +94,7 @@ a:hover {
   font-size: 0.78rem;
   font-weight: 400;
   font-style: italic;
-  color: var(--text-muted);
+  color: #7a6040;
   line-height: 1.3;
 }
 
@@ -114,18 +114,18 @@ a:hover {
   display: block;
   padding: 0.35rem 1.25rem;
   font-size: 0.875rem;
-  color: var(--text-muted);
+  color: #9e8a6a;
   text-decoration: none;
   border-left: 2px solid transparent;
   transition: background 0.12s, color 0.12s, border-color 0.12s;
 }
 .nav-top li a:hover {
   background: var(--active-bg);
-  color: var(--heading);
+  color: #ddc8a0;
 }
 .nav-top li a.active {
   border-left-color: var(--active-bar);
-  color: var(--heading);
+  color: #ddc8a0;
   background: var(--active-bg);
   font-weight: 500;
 }
@@ -141,7 +141,7 @@ a:hover {
   font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: var(--category);
+  color: #6fa04a;
   text-decoration: none;
   cursor: default;
 }
@@ -154,7 +154,7 @@ a:hover {
   display: block;
   padding: 0.3rem 1.25rem 0.3rem 1.5rem;
   font-size: 0.825rem;
-  color: var(--text-muted);
+  color: #9e8a6a;
   text-decoration: none;
   border-left: 2px solid transparent;
   line-height: 1.4;
@@ -162,11 +162,11 @@ a:hover {
 }
 .nav-category ul li a:hover {
   background: var(--active-bg);
-  color: var(--heading);
+  color: #ddc8a0;
 }
 .nav-category ul li a.active {
   border-left-color: var(--active-bar);
-  color: var(--heading);
+  color: #ddc8a0;
   background: var(--active-bg);
   font-weight: 500;
 }
@@ -179,8 +179,8 @@ a:hover {
   left: 1rem;
   z-index: 200;
   background: var(--sidebar-bg);
-  border: 1px solid var(--border);
-  color: var(--text);
+  border: 1px solid var(--sidebar-border);
+  color: #9e8a6a;
   font-size: 1.2rem;
   width: 2.5rem;
   height: 2.5rem;
@@ -261,15 +261,18 @@ a:hover {
 
 /* ── Landing / Contents page ────────────────────────────────── */
 .landing-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 2px solid var(--accent);
 }
 
 .landing-title {
-  font-size: 1.75rem;
+  font-size: 2.4rem;
   font-weight: 600;
-  line-height: 1.25;
+  line-height: 1.2;
   color: var(--heading);
-  margin-bottom: 0.3rem;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.5rem;
 }
 
 .landing-byline {
@@ -289,22 +292,31 @@ a:hover {
 
 .toc-frontmatter {
   display: flex;
-  gap: 2rem;
-  padding-bottom: 1.5rem;
+  gap: 0.75rem;
+  padding-bottom: 2rem;
   margin-bottom: 0.5rem;
   border-bottom: 1px solid var(--border);
 }
 
 .toc-frontmatter-link {
-  font-size: 1rem;
+  font-size: 0.875rem;
   font-weight: 500;
   text-decoration: none;
   color: var(--link);
+  padding: 0.4rem 0.85rem;
+  border: 1px solid var(--border);
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
 }
-.toc-frontmatter-link:hover { color: var(--link-hover); }
+.toc-frontmatter-link:hover {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: var(--accent-light);
+  color: var(--heading);
+}
 
 .toc-section {
-  margin-top: 2rem;
+  margin-top: 2.25rem;
+  padding-left: 1.1rem;
+  border-left: 2px solid var(--border);
 }
 
 .toc-section-title {
@@ -312,7 +324,7 @@ a:hover {
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--category);
+  color: var(--accent);
   margin-bottom: 0.75rem;
 }
 


### PR DESCRIPTION
Redesigns the PMP site landing page with more visual contrast.

- Dark warm sidebar (#1a0f06) with cream/sage text
- Larger landing title (2.4rem) with amber bottom rule
- TOC category sections with left border rules and amber labels
- Introduction/About styled as bordered button-links (were floating, looked broken)
- Three static design previews included (preview-a/b/c.html) for reference